### PR TITLE
less `new` madness

### DIFF
--- a/lib/negotiator.js
+++ b/lib/negotiator.js
@@ -2,6 +2,7 @@ module.exports = Negotiator;
 Negotiator.Negotiator = Negotiator;
 
 function Negotiator(request) {
+  if (!(this instanceof Negotiator)) return new Negotiator(request);
   this.request = request;
 }
 


### PR DESCRIPTION
so you can do `var negotiator = Negotiator(request)` without the `new`
