### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+examples
+test
+.travis.yml


### PR DESCRIPTION
Hi! I've added a `.npmignore` file for you here that will remove the test and example folders from the npm package, making it slimmer since they are not used at that point. It helps those that check in their `node_modules` directory for server deploys :)
