### PR TITLE
Fix behaviors when headers are not present

### DIFF
--- a/lib/charset.js
+++ b/lib/charset.js
@@ -56,7 +56,8 @@ function specify(charset, spec) {
 }
 
 function preferredCharsets(accept, provided) {
-  accept = parseAcceptCharset(accept || '');
+  // RFC 2616 sec 14.2: no header = *
+  accept = parseAcceptCharset(accept === undefined ? '*' : accept || '');
   if (provided) {
     return provided.map(function(type) {
       return [type, getCharsetPriority(type, accept)];

--- a/lib/language.js
+++ b/lib/language.js
@@ -67,7 +67,8 @@ function specify(language, spec) {
 };
 
 function preferredLanguages(accept, provided) {
-  accept = parseAcceptLanguage(accept || '');
+  // RFC 2616 sec 14.4: no header = *
+  accept = parseAcceptLanguage(accept === undefined ? '*' : accept || '');
   if (provided) {
 
     var ret = provided.map(function(type) {

--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -85,7 +85,8 @@ function specify(type, spec) {
 }
 
 function preferredMediaTypes(accept, provided) {
-  accept = parseAccept(accept || '');
+  // RFC 2616 sec 14.2: no header = */*
+  accept = parseAccept(accept === undefined ? '*/*' : accept || '');
   if (provided) {
     return provided.map(function(type) {
       return [type, getMediaTypePriority(type, accept)];

--- a/test/charset.js
+++ b/test/charset.js
@@ -28,6 +28,10 @@
 
   testConfigurations = [
     {
+      accept: undefined,
+      provided: ['utf-8'],
+      selected: ['utf-8']
+    }, {
       accept: 'utf-8',
       provided: ['utf-8'],
       selected: ['utf-8']

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -38,6 +38,10 @@
 
   testConfigurations = [
     {
+      accept: undefined,
+      provided: ['identity', 'gzip'],
+      selected: ['identity']
+    }, {
       accept: 'gzip',
       provided: ['identity', 'gzip'],
       selected: ['gzip', 'identity']

--- a/test/language.js
+++ b/test/language.js
@@ -28,6 +28,10 @@
 
   testConfigurations = [
     {
+      accept: undefined,
+      provided: ['en'],
+      selected: ['en']
+    }, {
       accept: 'en',
       provided: ['en'],
       selected: ['en']

--- a/test/mediaType.js
+++ b/test/mediaType.js
@@ -35,6 +35,10 @@
 
   testConfigurations = [
     {
+      accept: undefined,
+      provided: ['text/html'],
+      selected: ['text/html']
+    }, {
       accept: 'text/html',
       provided: ['text/html'],
       selected: ['text/html']


### PR DESCRIPTION
Hi! I was using your module and I noticed we kept responding with 406 to a certain client. It turns out the client had a privacy proxy running and was not sending any `Accept` header with the request. I checked in RFC 2616 and apparently they have information on what should be done if the header is missing. I updated the different modules with the RFC 2616 recommendations and added tests for the missing header cases.

Since `new Negotiator(req)` will pass `req.headers[name]` down to the modules, a missing header would pass down `undefined`, so I added the support for `undefined` to all the modules (it makes sense anyway, because the acceptable media type is not defined :))

RFC 2616 14.1

> If no Accept header field is present, then it is assumed that the client accepts all media types.

RFC 2616 14.2

> If no Accept-Charset header is present, the default is that any character set is acceptable.

RFC 2616 14.3

> If no Accept-Encoding field is present in a request, the server MAY assume that the client will accept any content coding. In this case, if "identity" is one of the available content-codings, then the server SHOULD use the "identity" content-coding, unless it has additional information that a different content-coding is meaningful to the client. 

RFC 2616 14.4

> If no Accept-Language header is present in the request, the server SHOULD assume that all languages are equally acceptable.

Right now using this module as `new Negotiator(req)` results in a violation of section 14.1 and 14.2 of RFC 2616. Sections 14.3 and 14.4 are nice to have (and 14.3 already occurs, I just added a test for it).
