### PR TITLE
mediaType: handle invalid provided content types

### DIFF
--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -57,6 +57,11 @@ function getMediaTypePriority(type, accepted) {
 function specify(type, spec) {
   var p = parseMediaType(type);
   var s = 0;
+
+  if (!p) {
+    return null;
+  }
+
   if(spec.type == p.type) {
     s |= 4
   } else if(spec.type != '*') {

--- a/test/mediaType.js
+++ b/test/mediaType.js
@@ -114,6 +114,10 @@
       accept : 'text/html, application/xhtml+xml, */*',
       provided : ['application/json', 'text/html'],
       selected : ['text/html', 'application/json' ]
+    }, {
+      accept : 'text/html, application/json',
+      provided : ['text/html', 'boom'],
+      selected : ['text/html']
     }
 
   ];


### PR DESCRIPTION
If a user specifies an invalid content type

```
new Negotiator(req).mediaType(['boom'])
```

negotiator blows up with a null pointer error. Handle this case by
ignoring the invalid provided content type.
