### PR TITLE
Remove checks for the same specificity of different accept entries

### DIFF
--- a/lib/charset.js
+++ b/lib/charset.js
@@ -36,11 +36,7 @@ function getCharsetPriority(charset, accepted) {
   return (accepted.map(function(a) {
     return specify(charset, a);
   }).filter(Boolean).sort(function (a, b) {
-    if(a.s == b.s) {
-      return a.q > b.q ? -1 : 1;
-    } else {
-      return a.s > b.s ? -1 : 1;
-    }
+    return a.s > b.s ? -1 : 1;
   })[0] || {s: 0, q:0});
 }
 

--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -67,11 +67,7 @@ function getEncodingPriority(encoding, accepted) {
   return (accepted.map(function(a) {
     return specify(encoding, a);
   }).filter(Boolean).sort(function (a, b) {
-    if(a.s == b.s) {
-      return a.q > b.q ? -1 : 1;
-    } else {
-      return a.s > b.s ? -1 : 1;
-    }
+    return a.s > b.s ? -1 : 1;
   })[0] || {s: 0, q: 0});
 }
 

--- a/lib/language.js
+++ b/lib/language.js
@@ -40,11 +40,7 @@ function getLanguagePriority(language, accepted) {
   return (accepted.map(function(a){
     return specify(language, a);
   }).filter(Boolean).sort(function (a, b) {
-    if(a.s == b.s) {
-      return a.q > b.q ? -1 : 1;
-    } else {
-      return a.s > b.s ? -1 : 1;
-    }
+    return a.s > b.s ? -1 : 1;
   })[0] || {s: 0, q: 0});
 }
 

--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -46,11 +46,7 @@ function getMediaTypePriority(type, accepted) {
   return (accepted.map(function(a) {
     return specify(type, a);
   }).filter(Boolean).sort(function (a, b) {
-    if(a.s == b.s) {
-      return a.q > b.q ? -1 : 1;
-    } else {
-      return a.s > b.s ? -1 : 1;
-    }
+    return a.s > b.s ? -1 : 1;
   })[0] || {s: 0, q: 0});
 }
 


### PR DESCRIPTION
As far as I can tell, the only case where this conditional (`a.s == b.s`) is true is where there are multiple entries in the accept header that have the same type, subtype, and params.  This scenario isn't mentioned in the RFC and I can't think of a real world use case for it.

Removing these helps #24 by getting line coverage to 100%.
