### PR TITLE
Use statically analyzable requires

### DIFF
--- a/lib/negotiator.js
+++ b/lib/negotiator.js
@@ -6,10 +6,10 @@ function Negotiator(request) {
   this.request = request;
 }
 
-var set = { charset: 'accept-charset',
-            encoding: 'accept-encoding',
-            language: 'accept-language',
-            mediaType: 'accept' };
+var set = { 'charset': { header: 'accept-charset', method: require('./charset.js') },
+            'encoding': { header: 'accept-encoding', method: require('./encoding.js') },
+            'language': { header: 'accept-language', method: require('./language.js') },
+            'mediaType': { header: 'accept', method: require('./mediaType.js') } };
 
 
 function capitalize(string){
@@ -17,8 +17,8 @@ function capitalize(string){
 }
 
 Object.keys(set).forEach(function (k) {
-  var header = set[k],
-      method = require('./'+k+'.js'),
+  var header = set[k].header,
+      method = set[k].method,
       singular = k,
       plural = k + 's';
 


### PR DESCRIPTION
For #32. I've tried to keep to the existing style in maintaining the requires as data. ~~We can potentially nest the object with `name`, `method` if you don't like the `split('-')` approach I'm using for extracting the name.~~

Thanks for consideration.
