### PR TITLE
use sorted order of provided content-types in negotiation

### DIFF
--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -52,11 +52,11 @@ function parseMediaType(s, i) {
   };
 }
 
-function getMediaTypePriority(type, accepted) {
+function getMediaTypePriority(type, accepted, order) {
   var priority = {i: -1, s: 0, q: 0};
 
   for (var i = 0; i < accepted.length; i++) {
-    var spec = specify(type, accepted[i]);
+    var spec = specify(type, accepted[i], order);
 
     if (spec && (priority.s - spec.s || priority.q - spec.q || priority.i - spec.i) < 0) {
       priority = spec;
@@ -66,7 +66,7 @@ function getMediaTypePriority(type, accepted) {
   return priority;
 }
 
-function specify(type, spec) {
+function specify(type, spec, order) {
   var p = parseMediaType(type);
   var s = 0;
 
@@ -99,7 +99,7 @@ function specify(type, spec) {
 
   return {
     q: spec.q,
-    i: spec.i,
+    i: order,
     s: s,
   }
 
@@ -116,8 +116,8 @@ function preferredMediaTypes(accept, provided) {
     });
   }
 
-  var priorities = provided.map(function getPriority(type) {
-    return getMediaTypePriority(type, accepts);
+  var priorities = provided.map(function getPriority(type, order) {
+    return getMediaTypePriority(type, accepts, order);
   });
 
   // sorted list of accepted types

--- a/test/mediaType.js
+++ b/test/mediaType.js
@@ -5,6 +5,36 @@ var Negotiator = require('..');
   var configuration, testConfigurations, testCorrectType, _i, _len,
     _this = this;
 
+  this["Should return list of media types in order"] = function(test) {
+    var request = createRequest({Accept: '*/*'});
+    var negotiator = new Negotiator(request);
+
+    var mediaTypes = [
+      'text/javascript',
+      'application/javascript',
+      'application/x-javascript',
+      'text/json',
+      'text/x-json',
+      'application/json',
+      'application/x-json',
+      'text/xml',
+      'application/xml',
+      'application/x-xml',
+      'text/html',
+      'application/xhtml+xml',
+      'text/yaml',
+      'text/x-yaml',
+      'application/yaml',
+      'application/x-yaml',
+      'text/plain'
+    ];
+
+    test.deepEqual(negotiator.mediaTypes(mediaTypes), mediaTypes);
+    test.strictEqual(negotiator.mediaType(mediaTypes), 'text/javascript');
+
+    return test.done();
+  };
+
   this["Should not return a media type when no media type provided"] = function(test) {
     var request = createRequest({Accept: '*/*'});
     var negotiator = new Negotiator(request);


### PR DESCRIPTION
been chasing this all the way from [express](https://github.com/strongloop/express/blob/master/lib/request.js#L107) to [jshttp/accepts](https://github.com/jshttp/accepts/blob/master/index.js#L58)...

this "feature" (sorting by provided array index) was originally introduced by @dougwilson  in 6fb679f4d836f579da5ac4b582b27e7ff57b6748 but doesn't seem to have ever worked, and no related tests for `mimeType.js` where `language.js` has one