### PR TITLE
Test that `Accept` parameter order is irrelevant

### DIFF
--- a/test/mediaType.js
+++ b/test/mediaType.js
@@ -343,6 +343,11 @@ describe('negotiator.mediaTypes(array)', function () {
       ['text/html;level=1;foo=bar'],
       ['text/html;level=1;foo=bar']
     ))
+
+    it('should accept text/html;foo=bar;level=1', mediaTypesNegotiated(
+      ['text/html;foo=bar;level=1'],
+      ['text/html;foo=bar;level=1']
+    ))
   })
 
   whenAccept('text/html;level=1;foo="bar"', function () {


### PR DESCRIPTION
The library is already agnostic about the order of parameters, which is great, but I just figured I'd add a test for that explicitly so that we don't get any regressions when we address #35 or in the future.

For reference, this is definitely correct behavior. RFC 2046 says straightforwardly that “The ordering of parameters is not significant.” (And my justification for referencing 2046 is that RFC 7231 says that “HTTP uses Internet media types [RFC2046] in the Content-Type and Accept header fields”.)