### PR TITLE
Accept-Language not interpreted correctly

### DIFF
--- a/test/language.js
+++ b/test/language.js
@@ -172,6 +172,12 @@ describe('negotiator.language(array)', function () {
     })
   })
 
+  whenAcceptLanguage('en, en-US;q=0.8', function() {
+    it('should use the supported language', function() {
+      assert.strictEqual(this.negotiator.language(['en-US', 'en-GB']), 'en-US')
+    })
+  })
+
   whenAcceptLanguage('en;q=0.9, es;q=0.8, en;q=0.7', function () {
     it('should use highest perferred order on duplicate', function () {
       assert.strictEqual(this.negotiator.language(['es']), 'es')


### PR DESCRIPTION
I just created a pr that illustrates what I see when trying to find the language from the accepts-language header. According to the docs, `languages` should return the best fit, and I am seeing unexpected behavior when I send in headers with values such as `en,en-US;q=0.8` which is standard US browser header value in Chrome.

If I call `language(['en-US', 'en-GB'])` I would expect the result to be en-US as that is an acceptable language that the server supports. The result is instead en-GB, leading me to believe there is a bug.
