### PR TITLE
Change resolved Accept-Encoding to honour server side order preferece

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Add configurable preferred sorting order for `Accept-Encoding`
+
 0.6.1 / 2016-05-02
 ==================
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ You can check a working example at `examples/encoding.js`.
 
 Returns the most preferred encoding from the client.
 
-##### encoding(availableEncodings)
+##### encoding(availableEncodings, options)
 
 Returns the most preferred encoding from a list of available encodings.
 
@@ -176,10 +176,20 @@ Returns the most preferred encoding from a list of available encodings.
 
 Returns an array of preferred encodings ordered by the client preference.
 
-##### encodings(availableEncodings)
+##### encodings(availableEncodings, options)
 
 Returns an array of preferred encodings ordered by priority from a list of
 available encodings.
+
+The options has one available option. The default value if not specified is
+```js
+{ sortPreference: 'client' }
+```
+
+#### Sort options
+`client`: sorts first by client quality level and then by client given order
+`clientThenServer`: sorts first by client quality level and then by server given order
+`server`: sorts by server given order
 
 ## See Also
 

--- a/index.js
+++ b/index.js
@@ -47,14 +47,14 @@ Negotiator.prototype.charsets = function charsets(available) {
   return preferredCharsets(this.request.headers['accept-charset'], available);
 };
 
-Negotiator.prototype.encoding = function encoding(available) {
-  var set = this.encodings(available);
+Negotiator.prototype.encoding = function encoding(available, options) {
+  var set = this.encodings(available, options);
   return set && set[0];
 };
 
-Negotiator.prototype.encodings = function encodings(available) {
+Negotiator.prototype.encodings = function encodings(available, options) {
   var preferredEncodings = loadModule('encoding').preferredEncodings;
-  return preferredEncodings(this.request.headers['accept-encoding'], available);
+  return preferredEncodings(this.request.headers['accept-encoding'], available, options);
 };
 
 Negotiator.prototype.language = function language(available) {

--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -22,6 +22,11 @@ module.exports.preferredEncodings = preferredEncodings;
  */
 
 var simpleEncodingRegExp = /^\s*([^\s;]+)\s*(?:;(.*))?$/;
+var comparators = {
+  client: compareSpecsPreferClient,
+  clientThenServer: compareSpecsPreferClientThenServer,
+  server: compareSpecsPreferServer
+};
 
 /**
  * Parse the Accept-Encoding header.
@@ -50,7 +55,7 @@ function parseAcceptEncoding(accept) {
      */
     accepts[j++] = {
       encoding: 'identity',
-      q: minQuality,
+      q: minQuality * 0.1,
       i: i
     };
   }
@@ -74,8 +79,8 @@ function parseEncoding(str, i) {
   var q = 1;
   if (match[2]) {
     var params = match[2].split(';');
-    for (var i = 0; i < params.length; i ++) {
-      var p = params[i].trim().split('=');
+    for (var j = 0; j < params.length; j ++) {
+      var p = params[j].trim().split('=');
       if (p[0] === 'q') {
         q = parseFloat(p[1]);
         break;
@@ -135,14 +140,14 @@ function specify(encoding, spec, index) {
  * @public
  */
 
-function preferredEncodings(accept, provided) {
+function preferredEncodings(accept, provided, options) {
   var accepts = parseAcceptEncoding(accept || '');
 
   if (!provided) {
     // sorted list of all encodings
     return accepts
       .filter(isQuality)
-      .sort(compareSpecs)
+      .sort(compareSpecsPreferClient)
       .map(getFullEncoding);
   }
 
@@ -150,8 +155,10 @@ function preferredEncodings(accept, provided) {
     return getEncodingPriority(type, accepts, index);
   });
 
+  var comparator = options && comparators[options.sortPreference] || compareSpecsPreferClient
+
   // sorted list of accepted encodings
-  return priorities.filter(isQuality).sort(compareSpecs).map(function getEncoding(priority) {
+  return priorities.filter(isQuality).sort(comparator).map(function getEncoding(priority) {
     return provided[priorities.indexOf(priority)];
   });
 }
@@ -161,8 +168,26 @@ function preferredEncodings(accept, provided) {
  * @private
  */
 
-function compareSpecs(a, b) {
+function compareSpecsPreferClient(a, b) {
   return (b.q - a.q) || (b.s - a.s) || (a.o - b.o) || (a.i - b.i) || 0;
+}
+
+/**
+ * Compare two specs.
+ * @private
+ */
+
+function compareSpecsPreferClientThenServer(a, b) {
+  return (b.q - a.q) || (a.i - b.i) || 0;
+}
+
+/**
+ * Compare two specs, ignoring client quality levels.
+ * @private
+ */
+
+function compareSpecsPreferServer(a, b) {
+  return (a.i - b.i) || 0;
 }
 
 /**


### PR DESCRIPTION
...when comparing client provided encodings with equal quality
Also change the quality of automatically added identity encoding to be lower than other encodings instead of equal to lowest seen quality.

This change is required by https://github.com/pillarjs/send/pull/108 to be able to use the negotiator.
