### PR TITLE
stop lazy loading modules

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Revert "Lazy-load modules from main entry point"
+
 0.6.2 / 2019-04-29
 ==================
 

--- a/index.js
+++ b/index.js
@@ -8,12 +8,10 @@
 
 'use strict';
 
-/**
- * Cached loaded submodules.
- * @private
- */
-
-var modules = Object.create(null);
+var preferredCharsets = require('./lib/charset')
+var preferredEncodings = require('./lib/encoding')
+var preferredLanguages = require('./lib/language')
+var preferredMediaTypes = require('./lib/mediaType')
 
 /**
  * Module exports.
@@ -43,7 +41,6 @@ Negotiator.prototype.charset = function charset(available) {
 };
 
 Negotiator.prototype.charsets = function charsets(available) {
-  var preferredCharsets = loadModule('charset').preferredCharsets;
   return preferredCharsets(this.request.headers['accept-charset'], available);
 };
 
@@ -53,7 +50,6 @@ Negotiator.prototype.encoding = function encoding(available) {
 };
 
 Negotiator.prototype.encodings = function encodings(available) {
-  var preferredEncodings = loadModule('encoding').preferredEncodings;
   return preferredEncodings(this.request.headers['accept-encoding'], available);
 };
 
@@ -63,7 +59,6 @@ Negotiator.prototype.language = function language(available) {
 };
 
 Negotiator.prototype.languages = function languages(available) {
-  var preferredLanguages = loadModule('language').preferredLanguages;
   return preferredLanguages(this.request.headers['accept-language'], available);
 };
 
@@ -73,7 +68,6 @@ Negotiator.prototype.mediaType = function mediaType(available) {
 };
 
 Negotiator.prototype.mediaTypes = function mediaTypes(available) {
-  var preferredMediaTypes = loadModule('mediaType').preferredMediaTypes;
   return preferredMediaTypes(this.request.headers.accept, available);
 };
 
@@ -86,39 +80,3 @@ Negotiator.prototype.preferredLanguage = Negotiator.prototype.language;
 Negotiator.prototype.preferredLanguages = Negotiator.prototype.languages;
 Negotiator.prototype.preferredMediaType = Negotiator.prototype.mediaType;
 Negotiator.prototype.preferredMediaTypes = Negotiator.prototype.mediaTypes;
-
-/**
- * Load the given module.
- * @private
- */
-
-function loadModule(moduleName) {
-  var module = modules[moduleName];
-
-  if (module !== undefined) {
-    return module;
-  }
-
-  // This uses a switch for static require analysis
-  switch (moduleName) {
-    case 'charset':
-      module = require('./lib/charset');
-      break;
-    case 'encoding':
-      module = require('./lib/encoding');
-      break;
-    case 'language':
-      module = require('./lib/language');
-      break;
-    case 'mediaType':
-      module = require('./lib/mediaType');
-      break;
-    default:
-      throw new Error('Cannot find module \'' + moduleName + '\'');
-  }
-
-  // Store to prevent invoking require()
-  modules[moduleName] = module;
-
-  return module;
-}


### PR DESCRIPTION
the lazy loading here caused us some minor grief when introducing this module to the npm CLI. the modules that are being lazy loaded do not have any requires of their own and are comprised of largely function definitions, which are pretty cheap in the grand scheme of things.

feel free to close this if the micro optimization is worth it for you! we just wanted to see if we could get this changed here instead of our current hacky workaround: https://github.com/npm/make-fetch-happen/pull/50