### PR TITLE
replace `mocha` and `nyc` with native node test runner and `c8`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,7 @@ jobs:
 
     - name: Run tests
       shell: bash
-      run: |
-        if npm -ps ls nyc | grep -q nyc; then
-          npm run test-ci
-        else
-          npm test
-        fi
+      run: npm run test-ci
 
     - name: Lint code
       if: steps.list_env.outputs.eslint != ''
@@ -83,7 +78,6 @@ jobs:
 
     - name: Collect code coverage
       uses: coverallsapp/github-action@master
-      if: steps.list_env.outputs.nyc != ''
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         flag-name: run-${{ matrix.test_number }}

--- a/package.json
+++ b/package.json
@@ -18,10 +18,9 @@
   ],
   "repository": "jshttp/negotiator",
   "devDependencies": {
+    "c8": "^10.1.2",
     "eslint": "7.32.0",
-    "eslint-plugin-markdown": "2.2.1",
-    "mocha": "9.1.3",
-    "nyc": "15.1.0"
+    "eslint-plugin-markdown": "2.2.1"
   },
   "files": [
     "lib/",
@@ -35,9 +34,8 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --reporter spec --check-leaks --bail test/",
-    "test:debug": "mocha --reporter spec --check-leaks --inspect --inspect-brk test/",
-    "test-ci": "nyc --reporter=lcov --reporter=text npm test",
-    "test-cov": "nyc --reporter=html --reporter=text npm test"
+    "test": "node --test --test-reporter spec",
+    "test-ci": "c8 --reporter=lcovonly --reporter=text npm test",
+    "test-cov": "c8 --reporter=html --reporter=text npm test"
   }
 }

--- a/test/charset.js
+++ b/test/charset.js
@@ -1,4 +1,7 @@
-
+var nodeTest = require('node:test')
+var describe = nodeTest.describe
+var it = nodeTest.it
+var before = nodeTest.before
 var assert = require('assert')
 var Negotiator = require('..')
 
@@ -326,10 +329,12 @@ function whenAcceptCharset(acceptCharset, func) {
     : 'when Accept-Charset: ' + acceptCharset
 
   describe(description, function () {
+    var thisArg = {}
+
     before(function () {
-      this.negotiator = new Negotiator(createRequest({'Accept-Charset': acceptCharset}))
+      thisArg.negotiator = new Negotiator(createRequest({'Accept-Charset': acceptCharset}))
     })
 
-    func()
+    func.bind(thisArg)
   })
 }

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1,4 +1,7 @@
-
+var nodeTest = require('node:test')
+var describe = nodeTest.describe
+var it = nodeTest.it
+var before = nodeTest.before
 var assert = require('assert')
 var Negotiator = require('..')
 
@@ -467,10 +470,12 @@ function whenAcceptEncoding(acceptEncoding, func) {
     : 'when Accept-Encoding: ' + acceptEncoding
 
   describe(description, function () {
+    var thisArg = {}
+
     before(function () {
-      this.negotiator = new Negotiator(createRequest({'Accept-Encoding': acceptEncoding}))
+      thisArg.negotiator = new Negotiator(createRequest({'Accept-Encoding': acceptEncoding}))
     })
 
-    func()
+    func.bind(thisArg)
   })
 }

--- a/test/language.js
+++ b/test/language.js
@@ -1,4 +1,7 @@
-
+var nodeTest = require('node:test')
+var describe = nodeTest.describe
+var it = nodeTest.it
+var before = nodeTest.before
 var assert = require('assert')
 var Negotiator = require('..')
 
@@ -422,10 +425,12 @@ function whenAcceptLanguage(acceptLanguage, func) {
     : 'when Accept-Language: ' + acceptLanguage
 
   describe(description, function () {
+    var thisArg = {}
+
     before(function () {
-      this.negotiator = new Negotiator(createRequest({'Accept-Language': acceptLanguage}))
+      thisArg.negotiator = new Negotiator(createRequest({'Accept-Language': acceptLanguage}))
     })
 
-    func()
+    func.bind(thisArg)
   })
 }

--- a/test/mediaType.js
+++ b/test/mediaType.js
@@ -1,4 +1,7 @@
-
+var nodeTest = require('node:test')
+var describe = nodeTest.describe
+var it = nodeTest.it
+var before = nodeTest.before
 var assert = require('assert')
 var Negotiator = require('..')
 
@@ -490,10 +493,12 @@ function whenAccept(accept, func) {
     : 'when Accept: ' + accept
 
   describe(description, function () {
+    var thisArg = {}
+
     before(function () {
-      this.negotiator = Negotiator(createRequest({'Accept': accept}))
+      thisArg.negotiator = Negotiator(createRequest({ 'Accept': accept }))
     })
 
-    func()
+    func.bind(thisArg)
   })
 }


### PR DESCRIPTION
This PR refactors the test setup by replacing Mocha and NYC with Node.js's native test runner (`node:test`) and [`c8`](https://www.npmjs.com/package/c8) for coverage reporting.

**Key Changes:**
- Replaced Mocha and NYC with the native Node.js test runner and [`c8`](https://www.npmjs.com/package/c8) for code coverage.
- Updated test scripts to align with the new setup, improving maintainability and reducing reliance on external libraries.
- Updates the CI pipeline

**Benefits:**  
These changes modernize the testing framework, reduce external dependencies, and uphold code coverage standards using built-in Node.js capabilities.