### PR TITLE
ci: updated ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - '1.x'
     paths-ignore:
       - '*.md'
   pull_request:
@@ -15,94 +14,76 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 'lts/*'
+
+      - name: Install Node.js dependencies
+        run: npm install --ignore-scripts --include=dev
+
+      - name: Lint code
+        run: npm run lint
+
   test:
-    permissions:
-      checks: write  # for coverallsapp/github-action to create new checks
-      contents: read  # for actions/checkout to fetch code
+    name: Test - Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        name:
-        - Node.js 18.x
-        - Node.js 19.x
-        - Node.js 20.x
-        - Node.js 21.x
-        - Node.js 22.x
-
-        include:
-        - name: Node.js 18.x
-          node-version: "18"
-
-        - name: Node.js 19.x
-          node-version: "19"
-
-        - name: Node.js 20.x
-          node-version: "20"
-
-        - name: Node.js 21.x
-          node-version: "21"
-
-        - name: Node.js 22.x
-          node-version: "22"
+        # Node.js release schedule: https://nodejs.org/en/about/releases/
+        node-version: [18, 19, 20, 21, 22, 23, 24]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Install Node.js ${{ matrix.node-version }}
-      shell: bash -eo pipefail -l {0}
-      run: |
-        nvm install --default ${{ matrix.node-version }}
-        dirname "$(nvm which ${{ matrix.node-version }})" >> "$GITHUB_PATH"
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          check-latest: true
 
-    - name: Configure npm
-      run: |
-        if [[ "$(npm config get package-lock)" == "true" ]]; then
-          npm config set package-lock false
-        else
-          npm config set shrinkwrap false
-        fi
+      - name: Install Node.js dependencies
+        run: npm install
 
-    - name: Install Node.js dependencies
-      run: npm install
+      - name: Run tests
+        run: npm run test-ci
 
-    - name: List environment
-      id: list_env
-      shell: bash
-      run: |
-        echo "node@$(node -v)"
-        echo "npm@$(npm -v)"
-        npm -s ls ||:
-        (npm -s ls --depth=0 ||:) | awk -F'[ @]' 'NR>1 && $2 { print "::set-output name=" $2 "::" $3 }'
-
-    - name: Run tests
-      shell: bash
-      run: |
-        if npm -ps ls nyc | grep -q nyc; then
-          npm run test-ci
-        else
-          npm test
-        fi
-
-    - name: Lint code
-      if: steps.list_env.outputs.eslint != ''
-      run: npm run lint
-
-    - name: Collect code coverage
-      uses: coverallsapp/github-action@master
-      if: steps.list_env.outputs.nyc != ''
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: run-${{ matrix.test_number }}
-        parallel: true
+      - name: Upload code coverage
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-node-${{ matrix.node-version }}
+          path: ./coverage/lcov.info
+          retention-days: 1
 
   coverage:
-    permissions:
-      checks: write  # for coverallsapp/github-action to create new checks
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
-    - name: Upload code coverage
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        parallel-finished: true
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install lcov
+        shell: bash
+        run: sudo apt-get -y install lcov
+
+      - name: Collect coverage reports
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: ./coverage
+          pattern: coverage-node-*
+
+      - name: Merge coverage reports
+        shell: bash
+        run: find ./coverage -name lcov.info -exec printf '-a %q\n' {} \; | xargs lcov -o ./lcov.info
+
+      - name: Upload coverage report
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          file: ./lcov.info

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "devDependencies": {
     "eslint": "7.32.0",
     "eslint-plugin-markdown": "2.2.1",
-    "mocha": "9.1.3",
-    "nyc": "15.1.0"
+    "mocha": "^11.7.0",
+    "nyc": "^17.1.0"
   },
   "files": [
     "lib/",
@@ -39,9 +39,9 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --reporter spec --check-leaks --bail test/",
+    "test": "mocha --reporter spec --check-leaks test/",
     "test:debug": "mocha --reporter spec --check-leaks --inspect --inspect-brk test/",
-    "test-ci": "nyc --reporter=lcov --reporter=text npm test",
+    "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --reporter=html --reporter=text npm test"
   }
 }


### PR DESCRIPTION
This PR updates the CI pipeline to match the main express one:

- separate `lint` step
- test matrix with all supported node versions
- removed legacy coverage and test depdency checks
- use `actions/setup-node` to install Node.js
- use `coverallsapp/github-action` v2

This PR also removes `--bail` from the test script and updates the test dependencies and applies the caret notation to them.