### PR TITLE
Trim optional whitespace in the Accept-Language q-parameter

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Fix `Accept-Language` dropping a `q` value with whitespace after the `;`
+
 1.0.0 / 2024-08-31
 ==================
 

--- a/lib/language.js
+++ b/lib/language.js
@@ -64,7 +64,7 @@ function parseLanguage(str, i) {
   if (match[3]) {
     var params = match[3].split(';')
     for (var j = 0; j < params.length; j++) {
-      var p = params[j].split('=');
+      var p = params[j].trim().split('=');
       if (p[0] === 'q') q = parseFloat(p[1]);
     }
   }

--- a/test/language.js
+++ b/test/language.js
@@ -400,6 +400,43 @@ describe('negotiator.languages(array)', function () {
         ['fr', 'de', 'en', 'it', 'es', 'pt', 'no', 'se', 'fi', 'ro', 'nl'])
     })
   })
+
+  // RFC 7231 sec 5.3.1 allows OWS after the ";"; charset/encoding already trim it.
+  whenAcceptLanguage('en;q=0.9, fr; q=0.1', function () {
+    it('should ignore whitespace after the semicolon', function () {
+      assert.deepEqual(this.negotiator.languages(['en', 'fr']), ['en', 'fr'])
+    })
+  })
+
+  whenAcceptLanguage('en;q=0.9, fr;\tq=0.1', function () {
+    it('should treat a tab as optional whitespace', function () {
+      assert.deepEqual(this.negotiator.languages(['en', 'fr']), ['en', 'fr'])
+    })
+  })
+
+  whenAcceptLanguage('fr; q=0', function () {
+    it('should honor an explicit q=0 rejection', function () {
+      assert.deepEqual(this.negotiator.languages(['fr']), [])
+    })
+  })
+
+  whenAcceptLanguage('fr;   q=0', function () {
+    it('should honor q=0 through repeated whitespace', function () {
+      assert.deepEqual(this.negotiator.languages(['fr']), [])
+    })
+  })
+
+  whenAcceptLanguage('en; q= 0.1, fr;q=0.5', function () {
+    it('should parse a q-value surrounded by whitespace', function () {
+      assert.deepEqual(this.negotiator.languages(['en', 'fr']), ['fr', 'en'])
+    })
+  })
+
+  it('should order a spaced header the same as an unspaced one', function () {
+    var spaced = new Negotiator(createRequest({'Accept-Language': 'en;q=0.9, fr; q=0.1'}))
+    var packed = new Negotiator(createRequest({'Accept-Language': 'en;q=0.9, fr;q=0.1'}))
+    assert.deepEqual(spaced.languages(['en', 'fr']), packed.languages(['en', 'fr']))
+  })
 })
 
 function createRequest(headers) {


### PR DESCRIPTION
`parseLanguage()` splits the `q` parameter without trimming it, unlike the charset, encoding and mediaType parsers. RFC 7231 §5.3.1 allows optional whitespace after the `;`, so `en; q=0.1` leaves the key as `" q"` and the `q` value is silently dropped (defaulting to 1).

As a result `en;q=0.9, fr; q=0.1` sorts as `['fr', 'en']`, the reverse of the byte-identical `en;q=0.9, fr;q=0.1`. Worse, `fr; q=0` returns `['fr']` instead of `[]` — an explicit `q=0` rejection bypassed by a single space. `charset`/`encoding` return `[]` for that same input.

The fix is the `.trim()` the three siblings already apply. It was left out of `language.js` in 0484c74, the 2019 commit that fixed this same loop in all three parsers. Added a whitespace matrix to the language tests; full suite passes (255).
