### PR TITLE
fix: respect backslash-escaped quotes when splitting quoted parameters

### DIFF
--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -209,7 +209,7 @@ function isQuality(spec) {
 }
 
 /**
- * Count the number of quotes in a string.
+ * Count the number of unescaped quotes in a string.
  * @private
  */
 
@@ -217,8 +217,19 @@ function quoteCount(string) {
   var count = 0;
   var index = 0;
 
-  while ((index = string.indexOf('"', index)) !== -1) {
-    count++;
+  while (index < string.length) {
+    if (string[index] === '\\') {
+      // a backslash always escapes the next character in a quoted-pair
+      // (RFC 7230 section 3.2.6), including an escaped DQUOTE, so it must
+      // not be treated as closing the quoted string.
+      index += 2;
+      continue;
+    }
+
+    if (string[index] === '"') {
+      count++;
+    }
+
     index++;
   }
 

--- a/test/mediaType.js
+++ b/test/mediaType.js
@@ -181,6 +181,18 @@ describe('negotiator.mediaTypes()', function () {
     })
   })
 
+  whenAccept('text/html;p="\\"", application/json', function () {
+    it('should return text/html, application/json', function () {
+      assert.deepEqual(this.negotiator.mediaTypes(), ['text/html', 'application/json'])
+    })
+  })
+
+  whenAccept('text/html;p="a\\\\", application/json', function () {
+    it('should return text/html, application/json', function () {
+      assert.deepEqual(this.negotiator.mediaTypes(), ['text/html', 'application/json'])
+    })
+  })
+
   whenAccept('text/plain, application/json;q=0.5, text/html, */*;q=0.1', function () {
     it('should return text/plain, text/html, application/json, */*', function () {
       assert.deepEqual(this.negotiator.mediaTypes(), ['text/plain', 'text/html', 'application/json', '*/*'])


### PR DESCRIPTION
## Summary
`quoteCount()` counts every literal DQUOTE to decide whether a comma/semicolon falls inside an open quoted-string, with no awareness of a preceding backslash. Per [RFC 7230 §3.2.6](https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6), `quoted-pair` allows an escaped DQUOTE inside a quoted-string without closing it — so a parameter value containing `\"` throws off the parity count, and the parser thinks it's still inside a quoted string when the next media type begins.

```js
var Negotiator = require('negotiator')
var n = new Negotiator({ headers: { accept: 'text/html;p="\\"", application/json' } })
n.mediaType(['application/json'])   // undefined -- should be 'application/json'
```

A perfectly valid Accept header that explicitly lists `application/json` gets it silently dropped, which could cause `accepts`/Express's `res.format()` to return a wrong-content-type response or a spurious 406.

## Changes
- `lib/mediaType.js`: `quoteCount()` now walks the string char-by-char, skipping the character after any backslash instead of naively counting every DQUOTE.
- `test/mediaType.js`: two new cases alongside the existing unescaped-comma-in-quotes test (issue #36) — an escaped DQUOTE, and an escaped backslash immediately before a real closing DQUOTE (to confirm double-backslash doesn't false-positive).

## Testing
- Full suite: 251/251 passing (3 pending, pre-existing/unrelated).
- `eslint .` clean.
- Manually verified before/after with the repro above.