### PR TITLE
Use `content-type` for accepts parsing

### DIFF
--- a/benchmarks/accept-charset.bench.mjs
+++ b/benchmarks/accept-charset.bench.mjs
@@ -1,0 +1,37 @@
+import { bench, describe } from 'vitest'
+import Negotiator from '../index.js'
+
+const complexAcceptCharset = 'utf-8, iso-8859-1;q=0.8, utf-7;q=0.2, iso-8859-5;q=0.6, utf-16;q=0.4, us-ascii;q=0.1, *;q=0.05'
+const providedCharsets = [
+  'utf-8',
+  'utf-16',
+  'iso-8859-1',
+  'iso-8859-5',
+  'us-ascii',
+  'windows-1252'
+]
+
+function createNegotiator(acceptCharset) {
+  return new Negotiator({ headers: { 'accept-charset': acceptCharset } })
+}
+
+describe('Accept-Charset header', () => {
+  const simple = createNegotiator('utf-8, iso-8859-1;q=0.5, *;q=0.1')
+  const complex = createNegotiator(complexAcceptCharset)
+
+  bench('parse a simple header', () => {
+    simple.charsets()
+  })
+
+  bench('parse a complex header', () => {
+    complex.charsets()
+  })
+
+  bench('negotiate provided charsets', () => {
+    complex.charsets(providedCharsets)
+  })
+
+  bench('select the preferred charset', () => {
+    complex.charset(providedCharsets)
+  })
+})

--- a/benchmarks/accept-encoding.bench.mjs
+++ b/benchmarks/accept-encoding.bench.mjs
@@ -1,0 +1,37 @@
+import { bench, describe } from 'vitest'
+import Negotiator from '../index.js'
+
+const complexAcceptEncoding = 'br, gzip;q=0.9, deflate;q=0.8, zstd;q=0.7, compress;q=0.5, identity;q=0.1, *;q=0.05'
+const providedEncodings = [
+  'br',
+  'gzip',
+  'deflate',
+  'zstd',
+  'compress',
+  'identity'
+]
+
+function createNegotiator(acceptEncoding) {
+  return new Negotiator({ headers: { 'accept-encoding': acceptEncoding } })
+}
+
+describe('Accept-Encoding header', () => {
+  const simple = createNegotiator('gzip, deflate;q=0.5, *;q=0.1')
+  const complex = createNegotiator(complexAcceptEncoding)
+
+  bench('parse a simple header', () => {
+    simple.encodings()
+  })
+
+  bench('parse a complex header', () => {
+    complex.encodings()
+  })
+
+  bench('negotiate provided encodings', () => {
+    complex.encodings(providedEncodings)
+  })
+
+  bench('select the preferred encoding', () => {
+    complex.encoding(providedEncodings)
+  })
+})

--- a/benchmarks/accept-language.bench.mjs
+++ b/benchmarks/accept-language.bench.mjs
@@ -1,0 +1,38 @@
+import { bench, describe } from 'vitest'
+import Negotiator from '../index.js'
+
+const complexAcceptLanguage = 'en-US, en;q=0.9, es-ES;q=0.8, fr-FR;q=0.7, de-DE;q=0.6, ja-JP;q=0.5, zh-CN;q=0.4, *;q=0.1'
+const providedLanguages = [
+  'en-US',
+  'en-GB',
+  'es-ES',
+  'fr-FR',
+  'de-DE',
+  'ja-JP',
+  'zh-CN'
+]
+
+function createNegotiator(acceptLanguage) {
+  return new Negotiator({ headers: { 'accept-language': acceptLanguage } })
+}
+
+describe('Accept-Language header', () => {
+  const simple = createNegotiator('en-US, en;q=0.5, *;q=0.1')
+  const complex = createNegotiator(complexAcceptLanguage)
+
+  bench('parse a simple header', () => {
+    simple.languages()
+  })
+
+  bench('parse a complex header', () => {
+    complex.languages()
+  })
+
+  bench('negotiate provided languages', () => {
+    complex.languages(providedLanguages)
+  })
+
+  bench('select the preferred language', () => {
+    complex.language(providedLanguages)
+  })
+})

--- a/benchmarks/accept.bench.mjs
+++ b/benchmarks/accept.bench.mjs
@@ -1,0 +1,44 @@
+import { bench, describe } from 'vitest'
+import Negotiator from '../index.js'
+
+const complexAccept = 'text/plain, application/json;q=0.5, text/html, text/xml, text/yaml, text/javascript, text/csv, text/css, text/rtf, text/markdown, application/octet-stream;q=0.2, */*;q=0.1'
+const providedMediaTypes = [
+  'text/html',
+  'text/plain',
+  'application/json',
+  'application/xml',
+  'image/jpeg',
+  'image/png',
+  'video/mp4',
+  'application/octet-stream'
+]
+
+function createNegotiator(accept) {
+  return new Negotiator({ headers: { accept } })
+}
+
+describe('Accept header', () => {
+  const simple = createNegotiator('text/html, application/json;q=0.5, */*;q=0.1')
+  const complex = createNegotiator(complexAccept)
+  const commas = createNegotiator('x;p="' + ','.repeat(100_000) + '"')
+
+  bench('parse a simple header', () => {
+    simple.mediaTypes()
+  })
+
+  bench('parse a complex header', () => {
+    complex.mediaTypes()
+  })
+
+  bench('parse a pathological header', () => {
+    commas.mediaTypes()
+  })
+
+  bench('negotiate provided media types', () => {
+    complex.mediaTypes(providedMediaTypes)
+  })
+
+  bench('select the preferred media type', () => {
+    complex.mediaType(providedMediaTypes)
+  })
+})

--- a/lib/accept.js
+++ b/lib/accept.js
@@ -1,0 +1,54 @@
+/*!
+ * negotiator
+ * Copyright(c) 2026 Blake Embrey
+ * MIT Licensed
+ */
+
+'use strict';
+
+var contentType = require('content-type');
+
+/**
+ * Module exports.
+ * @private
+ */
+
+module.exports = parseAccept;
+
+/**
+ * Parse an Accept-style header.
+ * @private
+ */
+
+function parseAccept(header) {
+  var values = [];
+  var index = 0;
+
+  while (index < header.length) {
+    var start = skipOptionalWhitespace(header, index);
+    var parsed = contentType.parse(header, { comma: true, start: start });
+
+    // `content-type` normalizes the type, but accept methods return original casing.
+    parsed.type = header.slice(start, start + parsed.type.length);
+    values.push(parsed);
+
+    index = parsed.index + 1;
+  }
+
+  return values;
+}
+
+/**
+ * Skip optional whitespace.
+ * @private
+ */
+
+function skipOptionalWhitespace(header, index) {
+  var cursor = index;
+
+  while (header.charCodeAt(cursor) === 0x20 || header.charCodeAt(cursor) === 0x09) {
+    cursor++;
+  }
+
+  return cursor;
+}

--- a/lib/charset.js
+++ b/lib/charset.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var parseAccept = require('./accept');
+
 /**
  * Module exports.
  * @public
@@ -21,55 +23,29 @@ module.exports.preferredCharsets = preferredCharsets;
  * @private
  */
 
-var simpleCharsetRegExp = /^\s*([^\s;]+)\s*(?:;(.*))?$/;
-
-/**
- * Parse the Accept-Charset header.
- * @private
- */
-
 function parseAcceptCharset(accept) {
-  var accepts = accept.split(',');
+  var accepts = parseAccept(accept);
 
   for (var i = 0, j = 0; i < accepts.length; i++) {
-    var charset = parseCharset(accepts[i].trim(), i);
-
-    if (charset) {
-      accepts[j++] = charset;
-    }
+    var charset = formatCharset(accepts[i], i);
+    if (charset) accepts[j++] = charset;
   }
 
-  // trim accepts
   accepts.length = j;
-
   return accepts;
 }
 
 /**
- * Parse a charset from the Accept-Charset header.
+ * Format a parsed charset for negotiation.
  * @private
  */
 
-function parseCharset(str, i) {
-  var match = simpleCharsetRegExp.exec(str);
-  if (!match) return null;
-
-  var charset = match[1];
-  var q = 1;
-  if (match[2]) {
-    var params = match[2].split(';')
-    for (var j = 0; j < params.length; j++) {
-      var p = params[j].trim().split('=');
-      if (p[0] === 'q') {
-        q = parseFloat(p[1]);
-        break;
-      }
-    }
-  }
+function formatCharset(parsed, i) {
+  if (!parsed.type) return null;
 
   return {
-    charset: charset,
-    q: q,
+    charset: parsed.type,
+    q: parsed.parameters.q ? parseFloat(parsed.parameters.q) : 1,
     i: i
   };
 }

--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var parseAccept = require('./accept');
+
 /**
  * Module exports.
  * @public
@@ -21,20 +23,13 @@ module.exports.preferredEncodings = preferredEncodings;
  * @private
  */
 
-var simpleEncodingRegExp = /^\s*([^\s;]+)\s*(?:;(.*))?$/;
-
-/**
- * Parse the Accept-Encoding header.
- * @private
- */
-
 function parseAcceptEncoding(accept) {
-  var accepts = accept.split(',');
+  var accepts = parseAccept(accept);
   var hasIdentity = false;
   var minQuality = 1;
 
   for (var i = 0, j = 0; i < accepts.length; i++) {
-    var encoding = parseEncoding(accepts[i].trim(), i);
+    var encoding = formatEncoding(accepts[i], i);
 
     if (encoding) {
       accepts[j++] = encoding;
@@ -55,37 +50,21 @@ function parseAcceptEncoding(accept) {
     };
   }
 
-  // trim accepts
   accepts.length = j;
-
   return accepts;
 }
 
 /**
- * Parse an encoding from the Accept-Encoding header.
+ * Format a parsed encoding for negotiation.
  * @private
  */
 
-function parseEncoding(str, i) {
-  var match = simpleEncodingRegExp.exec(str);
-  if (!match) return null;
-
-  var encoding = match[1];
-  var q = 1;
-  if (match[2]) {
-    var params = match[2].split(';');
-    for (var j = 0; j < params.length; j++) {
-      var p = params[j].trim().split('=');
-      if (p[0] === 'q') {
-        q = parseFloat(p[1]);
-        break;
-      }
-    }
-  }
+function formatEncoding(parsed, i) {
+  if (!parsed.type) return null;
 
   return {
-    encoding: encoding,
-    q: q,
+    encoding: parsed.type,
+    q: parsed.parameters.q ? parseFloat(parsed.parameters.q) : 1,
     i: i
   };
 }

--- a/lib/language.js
+++ b/lib/language.js
@@ -8,6 +8,9 @@
 
 'use strict';
 
+var contentType = require('content-type');
+var parseAccept = require('./accept');
+
 /**
  * Module exports.
  * @public
@@ -21,60 +24,36 @@ module.exports.preferredLanguages = preferredLanguages;
  * @private
  */
 
-var simpleLanguageRegExp = /^\s*([^\s\-;]+)(?:-([^\s;]+))?\s*(?:;(.*))?$/;
-
-/**
- * Parse the Accept-Language header.
- * @private
- */
-
 function parseAcceptLanguage(accept) {
-  var accepts = accept.split(',');
+  var accepts = parseAccept(accept);
 
   for (var i = 0, j = 0; i < accepts.length; i++) {
-    var language = parseLanguage(accepts[i].trim(), i);
-
-    if (language) {
-      accepts[j++] = language;
-    }
+    var language = formatLanguage(accepts[i], i);
+    if (language) accepts[j++] = language;
   }
 
-  // trim accepts
   accepts.length = j;
-
   return accepts;
 }
 
 /**
- * Parse a language from the Accept-Language header.
+ * Format a parsed language for negotiation.
  * @private
  */
 
-function parseLanguage(str, i) {
-  var match = simpleLanguageRegExp.exec(str);
-  if (!match) return null;
+function formatLanguage(parsed, i) {
+  if (!parsed.type) return null;
 
-  var prefix = match[1]
-  var suffix = match[2]
-  var full = prefix
-
-  if (suffix) full += "-" + suffix;
-
-  var q = 1;
-  if (match[3]) {
-    var params = match[3].split(';')
-    for (var j = 0; j < params.length; j++) {
-      var p = params[j].split('=');
-      if (p[0] === 'q') q = parseFloat(p[1]);
-    }
-  }
+  var hyphen = parsed.type.indexOf('-');
+  var prefix = hyphen === -1 ? parsed.type : parsed.type.slice(0, hyphen);
+  var suffix = hyphen === -1 ? undefined : parsed.type.slice(hyphen + 1);
 
   return {
     prefix: prefix,
     suffix: suffix,
-    q: q,
+    q: parsed.parameters.q ? parseFloat(parsed.parameters.q) : 1,
     i: i,
-    full: full
+    full: parsed.type
   };
 }
 
@@ -103,7 +82,7 @@ function getLanguagePriority(language, accepted, index) {
  */
 
 function specify(language, spec, index) {
-  var p = parseLanguage(language)
+  var p = formatLanguage(contentType.parse(language), 0)
   if (!p) return null;
   var s = 0;
   if(spec.full.toLowerCase() === p.full.toLowerCase()){

--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var contentType = require('content-type');
+
 /**
  * Module exports.
  * @public
@@ -21,71 +23,39 @@ module.exports.preferredMediaTypes = preferredMediaTypes;
  * @private
  */
 
-var simpleMediaTypeRegExp = /^\s*([^\s\/;]+)\/([^;\s]+)\s*(?:;(.*))?$/;
-
-/**
- * Parse the Accept header.
- * @private
- */
-
 function parseAccept(accept) {
-  var accepts = splitMediaTypes(accept);
+  var accepts = [];
+  var index = 0;
+  var position = 0;
 
-  for (var i = 0, j = 0; i < accepts.length; i++) {
-    var mediaType = parseMediaType(accepts[i].trim(), i);
+  while (index < accept.length) {
+    var parsed = contentType.parse(accept, { comma: true, start: index });
+    var mediaType = formatMediaType(parsed, position++);
+    if (mediaType) accepts.push(mediaType);
 
-    if (mediaType) {
-      accepts[j++] = mediaType;
-    }
+    index = parsed.index + 1;
   }
-
-  // trim accepts
-  accepts.length = j;
 
   return accepts;
 }
 
 /**
- * Parse a media type from the Accept header.
+ * Format a parsed content type for negotiation.
  * @private
  */
 
-function parseMediaType(str, i) {
-  var match = simpleMediaTypeRegExp.exec(str);
-  if (!match) return null;
+function formatMediaType(parsed, i) {
+  var slash = parsed.type.indexOf('/');
+  if (slash === -1) return null;
 
-  var params = Object.create(null);
-  var q = 1;
-  var subtype = match[2];
-  var type = match[1];
+  var q = parsed.parameters.q ? parseFloat(parsed.parameters.q) : 1;
 
-  if (match[3]) {
-    var kvps = splitParameters(match[3]).map(splitKeyValuePair);
-
-    for (var j = 0; j < kvps.length; j++) {
-      var pair = kvps[j];
-      var key = pair[0].toLowerCase();
-      var val = pair[1];
-
-      // get the value, unwrapping quotes
-      var value = val && val[0] === '"' && val[val.length - 1] === '"'
-        ? val.slice(1, -1)
-        : val;
-
-      if (key === 'q') {
-        q = parseFloat(value);
-        break;
-      }
-
-      // store parameter
-      params[key] = value;
-    }
-  }
+  delete parsed.parameters.q;
 
   return {
-    type: type,
-    subtype: subtype,
-    params: params,
+    type: parsed.type.slice(0, slash),
+    subtype: parsed.type.slice(slash + 1),
+    params: parsed.parameters,
     q: q,
     i: i
   };
@@ -116,7 +86,7 @@ function getMediaTypePriority(type, accepted, index) {
  */
 
 function specify(type, spec, index) {
-  var p = parseMediaType(type);
+  var p = formatMediaType(contentType.parse(type), 0);
   var s = 0;
 
   if (!p) {
@@ -206,89 +176,4 @@ function getFullType(spec) {
 
 function isQuality(spec) {
   return spec.q > 0;
-}
-
-/**
- * Count the number of quotes in a string.
- * @private
- */
-
-function quoteCount(string) {
-  var count = 0;
-  var index = 0;
-
-  while ((index = string.indexOf('"', index)) !== -1) {
-    count++;
-    index++;
-  }
-
-  return count;
-}
-
-/**
- * Split a key value pair.
- * @private
- */
-
-function splitKeyValuePair(str) {
-  var index = str.indexOf('=');
-  var key;
-  var val;
-
-  if (index === -1) {
-    key = str;
-  } else {
-    key = str.slice(0, index);
-    val = str.slice(index + 1);
-  }
-
-  return [key, val];
-}
-
-/**
- * Split an Accept header into media types.
- * @private
- */
-
-function splitMediaTypes(accept) {
-  var accepts = accept.split(',');
-
-  for (var i = 1, j = 0; i < accepts.length; i++) {
-    if (quoteCount(accepts[j]) % 2 == 0) {
-      accepts[++j] = accepts[i];
-    } else {
-      accepts[j] += ',' + accepts[i];
-    }
-  }
-
-  // trim accepts
-  accepts.length = j + 1;
-
-  return accepts;
-}
-
-/**
- * Split a string of parameters.
- * @private
- */
-
-function splitParameters(str) {
-  var parameters = str.split(';');
-
-  for (var i = 1, j = 0; i < parameters.length; i++) {
-    if (quoteCount(parameters[j]) % 2 == 0) {
-      parameters[++j] = parameters[i];
-    } else {
-      parameters[j] += ';' + parameters[i];
-    }
-  }
-
-  // trim parameters
-  parameters.length = j + 1;
-
-  for (var i = 0; i < parameters.length; i++) {
-    parameters[i] = parameters[i].trim();
-  }
-
-  return parameters;
 }

--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var contentType = require('content-type');
+var parseAcceptHeader = require('./accept');
 
 /**
  * Module exports.
@@ -24,18 +25,14 @@ module.exports.preferredMediaTypes = preferredMediaTypes;
  */
 
 function parseAccept(accept) {
-  var accepts = [];
-  var index = 0;
-  var position = 0;
+  var accepts = parseAcceptHeader(accept);
 
-  while (index < accept.length) {
-    var parsed = contentType.parse(accept, { comma: true, start: index });
-    var mediaType = formatMediaType(parsed, position++);
-    if (mediaType) accepts.push(mediaType);
-
-    index = parsed.index + 1;
+  for (var i = 0, j = 0; i < accepts.length; i++) {
+    var mediaType = formatMediaType(accepts[i], i);
+    if (mediaType) accepts[j++] = mediaType;
   }
 
+  accepts.length = j;
   return accepts;
 }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://opencollective.com/express"
   },
   "dependencies": {
-    "content-type": "2.1.0"
+    "content-type": "^2.1.0"
   },
   "devDependencies": {
     "eslint": "7.32.0",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,15 @@
     "type": "opencollective",
     "url": "https://opencollective.com/express"
   },
+  "dependencies": {
+    "content-type": "2.1.0"
+  },
   "devDependencies": {
     "eslint": "7.32.0",
     "eslint-plugin-markdown": "2.2.1",
     "mocha": "^11.7.0",
-    "nyc": "^17.1.0"
+    "nyc": "^17.1.0",
+    "vitest": "3.2.4"
   },
   "files": [
     "lib/",
@@ -38,6 +42,7 @@
     "node": ">=18"
   },
   "scripts": {
+    "bench": "vitest bench",
     "lint": "eslint .",
     "test": "mocha --reporter spec --check-leaks test/",
     "test:debug": "mocha --reporter spec --check-leaks --inspect --inspect-brk test/",

--- a/test/charset.js
+++ b/test/charset.js
@@ -206,6 +206,12 @@ describe('negotiator.charsets()', function () {
     })
   })
 
+  whenAcceptCharset('UTF-8;foo="bar,baz", ISO-8859-1', function () {
+    it('should handle commas in quoted parameters', function () {
+      assert.deepEqual(this.negotiator.charsets(), ['UTF-8', 'ISO-8859-1'])
+    })
+  })
+
   whenAcceptCharset('UTF-8;q=0.9, ISO-8859-1;q=0.8, UTF-8;q=0.7', function () {
     it.skip('should use highest perferred order on duplicate', function () {
       assert.deepEqual(this.negotiator.charsets(), ['UTF-8', 'ISO-8859-1'])

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -301,6 +301,12 @@ describe('negotiator.encodings()', function () {
     })
   })
 
+  whenAcceptEncoding('gzip;foo="bar,baz", deflate', function () {
+    it('should handle commas in quoted parameters', function () {
+      assert.deepEqual(this.negotiator.encodings(), ['gzip', 'deflate', 'identity'])
+    })
+  })
+
   whenAcceptEncoding('gzip;q=0.8, identity;q=0.5, *;q=0.3', function () {
     it('should return client-preferred encodings', function () {
       assert.deepEqual(this.negotiator.encodings(), ['gzip', 'identity', '*'])

--- a/test/language.js
+++ b/test/language.js
@@ -289,6 +289,12 @@ describe('negotiator.languages()', function () {
     })
   })
 
+  whenAcceptLanguage('en-US;foo="bar,baz", en-GB', function () {
+    it('should handle commas in quoted parameters', function () {
+      assert.deepEqual(this.negotiator.languages(), ['en-US', 'en-GB'])
+    })
+  })
+
   whenAcceptLanguage('nl;q=0.5, fr, de, en, it, es, pt, no, se, fi, ro', function () {
     it('should use prefer fr over nl', function () {
       assert.deepEqual(this.negotiator.languages(), ['fr', 'de', 'en', 'it', 'es', 'pt', 'no', 'se', 'fi', 'ro', 'nl'])

--- a/test/mediaType.js
+++ b/test/mediaType.js
@@ -181,6 +181,12 @@ describe('negotiator.mediaTypes()', function () {
     })
   })
 
+  whenAccept('text/html;foo="bar\\\"", application/json', function () {
+    it('should handle escaped quotes', function () {
+      assert.deepEqual(this.negotiator.mediaTypes(), ['text/html', 'application/json'])
+    })
+  })
+
   whenAccept('text/plain, application/json;q=0.5, text/html, */*;q=0.1', function () {
     it('should return text/plain, text/html, application/json, */*', function () {
       assert.deepEqual(this.negotiator.mediaTypes(), ['text/plain', 'text/html', 'application/json', '*/*'])
@@ -387,13 +393,13 @@ describe('negotiator.mediaTypes(array)', function () {
   })
 
   whenAccept('text/html;LEVEL=1;level=2', function () {
-    it('should accept text/html;level=2', mediaTypesNegotiated(
-      ['text/html;level=2'],
-      ['text/html;level=2']
+    it('should accept the first parameter value', mediaTypesNegotiated(
+      ['text/html;level=1'],
+      ['text/html;level=1']
     ))
 
-    it('should not accept text/html;level=1', mediaTypesNegotiated(
-      ['text/html;level=1'],
+    it('should not accept the duplicate parameter value', mediaTypesNegotiated(
+      ['text/html;level=2'],
       []
     ))
   })


### PR DESCRIPTION
Replaces the home grown `accepts` parsing with the `content-type` package. Also added the benchmarks I used, no major change in performance except for the comma handling.